### PR TITLE
CookieData

### DIFF
--- a/src/main/java/com/server/RequestHeaderParser.java
+++ b/src/main/java/com/server/RequestHeaderParser.java
@@ -1,5 +1,7 @@
 package com.server;
 
+import java.util.Hashtable;
+
 public class RequestHeaderParser {
 
     private String headerString;
@@ -11,7 +13,12 @@ public class RequestHeaderParser {
     }
 
     private void buildRequestParams() {
-        requestParams = new RequestParams(extractPath(), extractMethod());
+        requestParams = new RequestParamsBuilder()
+                .setPath(extractPath())
+                .setMethod(extractMethod())
+                .setQueryComponent(extractQueryComponent())
+                .setCookies(extractCookies())
+                .build();
     }
 
     private String extractMethod() {
@@ -22,8 +29,48 @@ public class RequestHeaderParser {
 
     private String extractPath() {
         String requestLine = headerString.split("\n")[0];
-        String route = requestLine.split(" ")[1];
+        String uri = requestLine.split(" ")[1];
+        String route = uri.split("[?]")[0];
         return route.trim();
+    }
+
+    private Hashtable<String, String> extractQueryComponent() {
+        Hashtable<String, String> queryComponent = new Hashtable<>();
+        String requestLine = headerString.split("\n")[0];
+        String uri = requestLine.split(" ")[1];
+        if (uri.contains("?")) {
+            String component = uri.split("[?]")[1];
+            String[] queries = component.split("[&]");
+
+            for (String keyValuePair : queries) {
+                String[] query = keyValuePair.split("[=]");
+                queryComponent.put(query[0], query[1]);
+            }
+        }
+        return queryComponent;
+    }
+
+    private Hashtable<String, String> extractCookies() {
+        Hashtable<String, String> cookieTable = new Hashtable<>();
+
+        if (headerString.contains("Cookie: ")) {
+            String cookieLine = "";
+            String[] headers = headerString.split("\r\n");
+            for ( String headerLine : headers) {
+                if (headerLine.contains("Cookie: ")) {
+                    cookieLine = headerLine;
+                    cookieLine = cookieLine.replace("Cookie: ", "");
+                    break;
+                }
+            }
+            String[] cookies = cookieLine.split("; ");
+            for (String cookieKeyValue : cookies) {
+                String key = cookieKeyValue.split("[=]")[0];
+                String value = cookieKeyValue.split("[=]")[1];
+                cookieTable.put(key, value);
+            }
+        }
+        return cookieTable;
     }
 
     public RequestParams getRequestParams() {

--- a/src/main/java/com/server/RequestHeaderReader.java
+++ b/src/main/java/com/server/RequestHeaderReader.java
@@ -16,6 +16,7 @@ public class RequestHeaderReader {
         StringBuilder header = new StringBuilder();
         while(!(line = br.readLine()).equals("")){
             header.append(line);
+            header.append("\r\n");
         }
         return header.toString().trim();
     }

--- a/src/main/java/com/server/RequestParams.java
+++ b/src/main/java/com/server/RequestParams.java
@@ -7,17 +7,16 @@ public class RequestParams {
     private String path;
     private String method;
     private Hashtable<String, String> queryComponent;
+    private Hashtable<String, String> cookies;
 
-    public RequestParams(String path, String method) {
-        this.path = path;
-        this.method = method;
-        this.queryComponent = new Hashtable();
-    }
-
-    public RequestParams(String path, String method, Hashtable queryComponent) {
+    public RequestParams(String path, String method, Hashtable<String, String> queryComponent, Hashtable<String, String> cookies) throws NullPointerException {
+        if ((path == null) || (method == null)) {
+            throw new NullPointerException();
+        }
         this.path = path;
         this.method = method;
         this.queryComponent = queryComponent;
+        this.cookies = cookies;
     }
 
     public String getPath() {
@@ -30,5 +29,9 @@ public class RequestParams {
 
     public Hashtable getQueryComponent() {
         return this.queryComponent;
+    }
+
+    public Hashtable getCookies() {
+        return this.cookies;
     }
 }

--- a/src/main/java/com/server/RequestParamsBuilder.java
+++ b/src/main/java/com/server/RequestParamsBuilder.java
@@ -1,0 +1,34 @@
+package com.server;
+
+import java.util.Hashtable;
+
+public class RequestParamsBuilder {
+    private String path;
+    private String method;
+    private Hashtable<String, String> queryComponent;
+    private Hashtable<String, String> cookies;
+
+    public RequestParamsBuilder setPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+    public RequestParamsBuilder setMethod(String method) {
+        this.method = method;
+        return this;
+    }
+
+    public RequestParamsBuilder setQueryComponent(Hashtable<String, String> queryComponent) {
+        this.queryComponent = queryComponent;
+        return this;
+    }
+
+    public RequestParamsBuilder setCookies(Hashtable<String, String> cookies) {
+        this.cookies = cookies;
+        return this;
+    }
+
+    public RequestParams build() {
+        return new RequestParams(path, method, queryComponent, cookies);
+    }
+}

--- a/src/main/java/com/server/RequestRouter.java
+++ b/src/main/java/com/server/RequestRouter.java
@@ -65,6 +65,9 @@ public class RequestRouter {
         addRoute("/text-file.txt", "GET", 200);
         addRoute("/coffee", "GET", 418);
         addRoute("/tea", "GET", 200);
+
+        addRoute("/cookie", "GET", 200);
+        addRoute("/eat_cookie", "GET", 200);
     }
 
     private void addRoute(String path, String method, int statusCode) {

--- a/src/main/java/com/server/ResponseBodyBuilder.java
+++ b/src/main/java/com/server/ResponseBodyBuilder.java
@@ -11,13 +11,21 @@ public class ResponseBodyBuilder {
         this.requestRouter = requestRouter;
         this.bodyHashtable = new Hashtable();
         bodyHashtable.put("/coffee", "I'm a teapot");
+        bodyHashtable.put("/cookie", "Eat");
     }
 
     public String getBody(RequestParams requestParams) {
+        if (requestParams.getPath().equals("/eat_cookie")){
+           bodyHashtable.put("/eat_cookie", eatCookieBody(requestParams));
+        }
         if(this.requestRouter.getResponseCode(requestParams) != 0){
             String value = (String)this.bodyHashtable.get(requestParams.getPath());
             this.body = value;
         }
         return this.body == null ? "" : this.body;
+    }
+
+    public String eatCookieBody(RequestParams requestParams) {
+       return "mmmm " + requestParams.getCookies().get("type");
     }
 }

--- a/src/main/java/com/server/ResponseHeaderBuilder.java
+++ b/src/main/java/com/server/ResponseHeaderBuilder.java
@@ -26,6 +26,10 @@ public class ResponseHeaderBuilder {
             ContentTypeHandler contentTypeHandler = new ContentTypeHandler();
             String contentTypeLine = contentTypeHandler.createLine(requestParams);
             appendLine(contentTypeLine);
+
+            SetCookieHandler setCookieHandler = new SetCookieHandler();
+            String setCookieHandlerLine = setCookieHandler.createLine(requestParams);
+            appendLine(setCookieHandlerLine);
         }
 
         return this.header + "\r\n";

--- a/src/main/java/com/server/SetCookieHandler.java
+++ b/src/main/java/com/server/SetCookieHandler.java
@@ -1,0 +1,31 @@
+package com.server;
+
+import java.util.Hashtable;
+
+public class SetCookieHandler implements IResponseHeaderHandler {
+    private Hashtable<String, String> setCookieHashtable;
+    private static final String SET_COOKIE_KEY = "Set-Cookie";
+
+    SetCookieHandler(){
+        this.setCookieHashtable = new Hashtable<>();
+    }
+
+    public String createLine(RequestParams requestParams){
+        if (requestParams.getPath().equals("/cookie")) {
+            setCookieHashtable.put("/cookie", cookiePathValue(requestParams));
+        }
+
+        String value = this.setCookieHashtable.get(requestParams.getPath());
+        return value == null ? "" : SET_COOKIE_KEY + ": " + value;
+    }
+
+    private String cookiePathValue(RequestParams requestParams) {
+        StringBuilder cookieString = new StringBuilder();
+        for (Object key : requestParams.getQueryComponent().keySet()) {
+            cookieString.append(key.toString());
+            cookieString.append("=");
+            cookieString.append(requestParams.getQueryComponent().get(key));
+        }
+        return cookieString.toString();
+    }
+}

--- a/src/test/java/com/server/AllowHandlerTest.java
+++ b/src/test/java/com/server/AllowHandlerTest.java
@@ -10,7 +10,7 @@ public class AllowHandlerTest {
         String path = "/method_options";
         String method = "OPTIONS";
         AllowHandler allowHandler = new AllowHandler();
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String result = allowHandler.createLine(requestParams);
 
         assertEquals("Allow: GET, PUT, OPTIONS, POST, HEAD", result);
@@ -21,7 +21,7 @@ public class AllowHandlerTest {
         String path = "/foo";
         String method = "GET";
         AllowHandler allowHandler = new AllowHandler();
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String result = allowHandler.createLine(requestParams);
 
         assertEquals("", result);

--- a/src/test/java/com/server/ContentTypeHandlerTest.java
+++ b/src/test/java/com/server/ContentTypeHandlerTest.java
@@ -11,7 +11,7 @@ public class ContentTypeHandlerTest {
         String path = "/image.jpeg";
         String method = "GET";
         ContentTypeHandler contentTypeHandler = new ContentTypeHandler();
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String result = contentTypeHandler.createLine(requestParams);
 
         assertEquals("Content-Type: image/jpeg", result);
@@ -22,7 +22,7 @@ public class ContentTypeHandlerTest {
         String path = "/foo";
         String method = "GET";
         ContentTypeHandler contentTypeHandler = new ContentTypeHandler();
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String result = contentTypeHandler.createLine(requestParams);
 
         assertEquals("", result);

--- a/src/test/java/com/server/LocationHandlerTest.java
+++ b/src/test/java/com/server/LocationHandlerTest.java
@@ -11,7 +11,7 @@ public class LocationHandlerTest {
         String path = "/redirect";
         String method = "GET";
         LocationHandler locationHandler = new LocationHandler();
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String result = locationHandler.createLine(requestParams);
 
         assertEquals("Location: /", result);
@@ -22,7 +22,7 @@ public class LocationHandlerTest {
         String path = "/foo";
         String method = "GET";
         LocationHandler locationHandler = new LocationHandler();
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String result = locationHandler.createLine(requestParams);
 
         assertEquals("", result);

--- a/src/test/java/com/server/MockRequestRouterTest.java
+++ b/src/test/java/com/server/MockRequestRouterTest.java
@@ -10,7 +10,7 @@ public class MockRequestRouterTest {
     public void checkPathReturns404ByDefault(){
 
         MockRequestRouter mockRequestRouter = new MockRequestRouter();
-        RequestParams requestParams = new RequestParams("", "");
+        RequestParams requestParams = new RequestParamsBuilder().setPath("").setMethod("").build();
 
         assertEquals(404, mockRequestRouter.getResponseCode(requestParams));
     }
@@ -21,7 +21,7 @@ public class MockRequestRouterTest {
         MockRequestRouter mockRequestRouter = new MockRequestRouter();
 
         mockRequestRouter.setResponseCode(200);
-        RequestParams requestParams = new RequestParams("", "");
+        RequestParams requestParams = new RequestParamsBuilder().setPath("").setMethod("").build();
 
         assertEquals(200, mockRequestRouter.getResponseCode(requestParams));
     }
@@ -32,7 +32,7 @@ public class MockRequestRouterTest {
         MockRequestRouter mockRequestRouter = new MockRequestRouter();
 
         mockRequestRouter.setResponseCode(404);
-        RequestParams requestParams = new RequestParams("", "");
+        RequestParams requestParams = new RequestParamsBuilder().setPath("").setMethod("").build();
 
         assertEquals(404, mockRequestRouter.getResponseCode(requestParams));
     }

--- a/src/test/java/com/server/RequestHeaderParserTest.java
+++ b/src/test/java/com/server/RequestHeaderParserTest.java
@@ -2,6 +2,8 @@ package com.server;
 
 import org.junit.Test;
 
+import java.util.Hashtable;
+
 import static org.junit.Assert.*;
 
 public class RequestHeaderParserTest {
@@ -44,5 +46,64 @@ public class RequestHeaderParserTest {
         RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
 
         assertEquals("/form", requestHeaderParser.getRequestParams().getPath());
+    }
+
+    @Test
+    public void getRouteReturnsPathWithoutQueryComponent() {
+
+        String headerString = "GET /cookie?type=chocolate HTTP/1.1";
+
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+
+        assertEquals("/cookie", requestHeaderParser.getRequestParams().getPath());
+    }
+
+    @Test
+    public void getQueryComponentReturnsAHashTableFromRequestURI() {
+
+        String headerString = "GET /cookie?type=chocolate&foo=bar HTTP/1.1";
+
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+
+        Hashtable result = requestHeaderParser.getRequestParams().getQueryComponent();
+
+        assertEquals("chocolate", result.get("type"));
+        assertEquals("bar", result.get("foo"));
+    }
+
+    @Test
+    public void getQueryComponentReturnsAnEmptyHashTableIfNoQueriesAreInURI() {
+
+        String headerString = "GET / HTTP/1.1";
+
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+
+        Hashtable result = requestHeaderParser.getRequestParams().getQueryComponent();
+
+        assertEquals(new Hashtable(), result);
+    }
+
+    @Test
+    public void getCookiesReturnsAHashTableFromRequestHeaders() {
+
+        String headerString = "GET /cookie HTTP/1.1\r\nCookie: type=chocolate\r\n\r\n";
+
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+
+        Hashtable result = requestHeaderParser.getRequestParams().getCookies();
+
+        assertEquals("chocolate", result.get("type"));
+    }
+
+    @Test
+    public void getCookieReturnsAnEmptyHashTableIfNoCookiesInRequestHeaders() {
+
+        String headerString = "GET /cookie?type=chocolate&foo=bar HTTP/1.1";
+
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+
+        Hashtable result = requestHeaderParser.getRequestParams().getCookies();
+
+        assertEquals(new Hashtable(), result);
     }
 }

--- a/src/test/java/com/server/RequestRouterTest.java
+++ b/src/test/java/com/server/RequestRouterTest.java
@@ -2,8 +2,6 @@ package com.server;
 
 import org.junit.Test;
 
-import java.util.Arrays;
-
 import static org.junit.Assert.*;
 
 public class RequestRouterTest {
@@ -13,7 +11,7 @@ public class RequestRouterTest {
         String path = "/";
         String method = "GET";
         RequestRouter requestRouter = new RequestRouter();
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         int result = requestRouter.getResponseCode(requestParams);
 
         assertEquals(200, result);
@@ -24,7 +22,7 @@ public class RequestRouterTest {
         String path = "/foobar";
         String method = "HEAD";
         RequestRouter requestRouter = new RequestRouter();
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         int result = requestRouter.getResponseCode(requestParams);
 
         assertEquals(404, result);
@@ -35,7 +33,7 @@ public class RequestRouterTest {
         String path = "/";
         String method = "DELETE";
         RequestRouter requestRouter = new RequestRouter();
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         int result = requestRouter.getResponseCode(requestParams);
 
         assertEquals(405, result);

--- a/src/test/java/com/server/ResponseBodyBuilderTest.java
+++ b/src/test/java/com/server/ResponseBodyBuilderTest.java
@@ -2,6 +2,8 @@ package com.server;
 
 import org.junit.Test;
 
+import java.util.Hashtable;
+
 import static org.junit.Assert.*;
 
 public class ResponseBodyBuilderTest {
@@ -12,10 +14,27 @@ public class ResponseBodyBuilderTest {
         String method = "GET";
         RequestRouter rr = new RequestRouter();
         ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String body = responseBodyBuilder.getBody(requestParams);
 
         String expected = "I'm a teapot";
+
+        assertEquals(expected, body);
+    }
+
+    @Test
+    public void getBodyReturnsMmmmChocolateIfRequestIncludesCookie(){
+        String path = "/eat_cookie";
+        String method = "GET";
+        Hashtable<String, String> cookies = new Hashtable<>();
+        cookies.put("type", "chocolate");
+
+        RequestRouter rr = new RequestRouter();
+        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setCookies(cookies).build();
+
+        String body = responseBodyBuilder.getBody(requestParams);
+        String expected = "mmmm chocolate";
 
         assertEquals(expected, body);
     }

--- a/src/test/java/com/server/ResponseBuilderTest.java
+++ b/src/test/java/com/server/ResponseBuilderTest.java
@@ -14,7 +14,7 @@ public class ResponseBuilderTest {
         ResponseHeaderBuilder rhb = new ResponseHeaderBuilder(rr);
         ResponseBodyBuilder rbb = new ResponseBodyBuilder(rr);
         ResponseBuilder responseBuilder = new ResponseBuilder(rhb, rbb);
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String response = responseBuilder.getResponse(requestParams);
 
         String expected = "HTTP/1.1 418 I'm a teapot\r\n\r\nI'm a teapot";
@@ -30,7 +30,7 @@ public class ResponseBuilderTest {
         ResponseHeaderBuilder rhb = new ResponseHeaderBuilder(rr);
         ResponseBodyBuilder rbb = new ResponseBodyBuilder(rr);
         ResponseBuilder responseBuilder = new ResponseBuilder(rhb, rbb);
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String response = responseBuilder.getResponse(requestParams);
 
         String expected = "HTTP/1.1 200 OK\r\n\r\n";

--- a/src/test/java/com/server/ResponseHeaderBuilderTest.java
+++ b/src/test/java/com/server/ResponseHeaderBuilderTest.java
@@ -13,7 +13,7 @@ public class ResponseHeaderBuilderTest {
         MockRequestRouter mrr = new MockRequestRouter();
         mrr.setResponseCode(200);
         ResponseHeaderBuilder responseHeaderBuilder = new ResponseHeaderBuilder(mrr);
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
 
         assertEquals("HTTP/1.1 200 OK\r\n\r\n", responseHeaderBuilder.getHeader(requestParams));
     }
@@ -25,7 +25,7 @@ public class ResponseHeaderBuilderTest {
         MockRequestRouter mrr = new MockRequestRouter();
         mrr.setResponseCode(200);
         ResponseHeaderBuilder responseHeaderBuilder = new ResponseHeaderBuilder(mrr);
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String header = responseHeaderBuilder.getHeader(requestParams);
 
         String expected = "HTTP/1.1 200 OK\r\nAllow: GET, PUT, OPTIONS, POST, HEAD\r\n\r\n";
@@ -40,7 +40,7 @@ public class ResponseHeaderBuilderTest {
         MockRequestRouter mrr = new MockRequestRouter();
         mrr.setResponseCode(405);
         ResponseHeaderBuilder responseHeaderBuilder = new ResponseHeaderBuilder(mrr);
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String header = responseHeaderBuilder.getHeader(requestParams);
 
         String expected = "HTTP/1.1 405 Method Not Allowed\r\n\r\n";

--- a/src/test/java/com/server/SetCookieHandlerTest.java
+++ b/src/test/java/com/server/SetCookieHandlerTest.java
@@ -1,0 +1,34 @@
+package com.server;
+
+import org.junit.Test;
+
+import java.util.Hashtable;
+
+import static org.junit.Assert.*;
+
+public class SetCookieHandlerTest {
+    @Test
+    public void createLineReturnsANewSetCookieLine(){
+        String path = "/cookie";
+        String method = "GET";
+        Hashtable<String, String> queryComponent = new Hashtable<>();
+        queryComponent.put("type", "chocolate");
+
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setQueryComponent(queryComponent).build();
+        SetCookieHandler setCookieHandler = new SetCookieHandler();
+        String result = setCookieHandler.createLine(requestParams);
+
+        assertEquals("Set-Cookie: type=chocolate", result);
+    }
+
+    @Test
+    public void createLineReturnsAnEmptyStringWhenPathIsNotFound(){
+        String path = "/foo";
+        String method = "GET";
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
+        SetCookieHandler setCookieHandler = new SetCookieHandler();
+        String result = setCookieHandler.createLine(requestParams);
+
+        assertEquals("", result);
+    }
+}

--- a/src/test/java/com/server/StatusHandlerTest.java
+++ b/src/test/java/com/server/StatusHandlerTest.java
@@ -13,7 +13,7 @@ public class StatusHandlerTest {
         StatusHandler statusHandler = new StatusHandler(mockRequestRouter);
         String path = "foo";
         String method = "bar";
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
 
         assertEquals("HTTP/1.1 200 OK", statusHandler.createLine(requestParams));
     }
@@ -25,7 +25,7 @@ public class StatusHandlerTest {
         StatusHandler statusHandler = new StatusHandler(mockRequestRouter);
         String path = "foo";
         String method = "bar";
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
 
         assertEquals("HTTP/1.1 302 Found", statusHandler.createLine(requestParams));
     }
@@ -37,7 +37,7 @@ public class StatusHandlerTest {
         StatusHandler statusHandler = new StatusHandler(mockRequestRouter);
         String path = "foo";
         String method = "bar";
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
 
         assertEquals("HTTP/1.1 404 Not Found", statusHandler.createLine(requestParams));
     }
@@ -49,7 +49,7 @@ public class StatusHandlerTest {
         StatusHandler statusHandler = new StatusHandler(mockRequestRouter);
         String path = "foo";
         String method = "bar";
-        RequestParams requestParams = new RequestParams(path, method);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
 
         assertEquals("HTTP/1.1 405 Method Not Allowed", statusHandler.createLine(requestParams));
     }


### PR DESCRIPTION
## Pivotal Link
https://www.pivotaltracker.com/story/show/159011756

## Description

In `RequestHeaderParser`, I wrote an `extractQueryComponent()` method to extract the query component from the uri. This is then stored in the `RequestParam` object. 

Next, I wrote an `extractCookies()` method that parses the cookie request header and stores them in a hashtable in the `QueryParam`.

I then created a `RequestParamBuilder`, using the builder pattern, so that we can more easily accommodate different requests without needed many different permutations of constructors. This refactoring also led to updating all the the tests that previously used the `RequestParam` constructor to use the `RequestParamBuilder` instead.

I needed to update the `RequestHeaderReader` to replace the `\r\n` delimiters between header lines. This is an important piece of the header that the `RequestHeaderParser` uses to distinguish between the Status Line and other header lines.

Next, I added the `/cookie` and `/eat_cookie` routes to the `RequestRouter`'s `routeTable`, and gave them the appropriate `responseCode` of `200`.

I then created a `SetCookieHandler` that implements the `ResponseHandler` interface and accepts the new `RequestParam` object in its `createLine()` method. The `createLine()` method first checks to see if the `requestParam.getPath()` is equal to `/cookie`. If it is, it builds the header using the `requestParams.getQueryComponent()` hashtable.

Finally, I updated the `ResponseBodyBuilder` to respond based on the value of the `Cookie` header, when the path is equal to `/get_cookie`. It does this by using the `requestParam.getCookies()` hashtable.


- [x] extract query component and hardcode response
- [x] extractPath separates path from query component
- [x] parse query component from header's request line
- [x] add /cookie route to router table
- [x] add response body for /cookie route
- [x] add SetCookieHandler to build Set-Cookier response header
- [x] add /eat_cookie to router
- [x] use SetCookieHandler in ResponseHeaderBuilder
- [x] add body response for /eat_cookie to body builder
- [x] use query component for request to dynamically populate set cookie response header
- [x] use builder to create request params
- [x] maintain header delimeter when reading request headers
- [x] use cookie value to build body