### PR TITLE
adding responseParams object

### DIFF
--- a/src/main/java/com/server/AllowHandler.java
+++ b/src/main/java/com/server/AllowHandler.java
@@ -12,7 +12,7 @@ public class AllowHandler implements IResponseHeaderHandler {
         allowHashtable.put("/method_options2", "GET, OPTIONS, HEAD");
     }
 
-    public String createLine(RequestParams requestParams){
+    public String createLine(RequestParams requestParams, ResponseParams responseParams){
         String value = (String)this.allowHashtable.get(requestParams.getPath());
         return value == null ? "" : ALLOW_KEY + ": " + value;
     }

--- a/src/main/java/com/server/ContentTypeHandler.java
+++ b/src/main/java/com/server/ContentTypeHandler.java
@@ -14,7 +14,7 @@ public class ContentTypeHandler implements IResponseHeaderHandler {
         contentTypeHashtable.put("/text-file.txt", "text/plain");
     }
 
-    public String createLine(RequestParams requestParams){
+    public String createLine(RequestParams requestParams, ResponseParams responseParams){
         String value = (String)this.contentTypeHashtable.get(requestParams.getPath());
         return value == null ? "" : CONTENT_TYPE_KEY + ": " + value;
     }

--- a/src/main/java/com/server/HTTPServerManager.java
+++ b/src/main/java/com/server/HTTPServerManager.java
@@ -23,15 +23,14 @@ public class HTTPServerManager {
             BufferedReader in = openInputStream(clientSocket);
 
             RequestReader requestHeaderReader = new RequestReader(in);
-            RequestHeaderParser requestHeaderParser = new RequestHeaderParser(requestHeaderReader.getHeader());
+            RequestHeaderParser requestHeaderParser = new RequestHeaderParser(requestHeaderReader.getHeader(), serverConfig.getDirectory());
 
             PrintWriter out = openOutputStream(clientSocket);
 
             RequestParams requestParams = requestHeaderParser.getRequestParams();
-            ResponseHeaderBuilder responseHeaderBuilder = new ResponseHeaderBuilder(requestRouter);
-            ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(requestRouter, serverConfig.getDirectory());
 
-            ResponseBuilder responseBuilder = new ResponseBuilder(responseHeaderBuilder, responseBodyBuilder);
+            ResponseBuilder responseBuilder = new ResponseBuilder(requestRouter);
+
 
             out.println(responseBuilder.getResponse(requestParams));
 

--- a/src/main/java/com/server/IResponseHeaderHandler.java
+++ b/src/main/java/com/server/IResponseHeaderHandler.java
@@ -2,5 +2,5 @@ package com.server;
 
 public interface IResponseHeaderHandler {
 
-    String createLine(RequestParams requestParams);
+    String createLine(RequestParams requestParams, ResponseParams responseParams);
 }

--- a/src/main/java/com/server/LocationHandler.java
+++ b/src/main/java/com/server/LocationHandler.java
@@ -11,7 +11,7 @@ public class LocationHandler implements IResponseHeaderHandler {
         locationHashtable.put("/redirect", "/");
     }
 
-    public String createLine(RequestParams requestParams){
+    public String createLine(RequestParams requestParams, ResponseParams responseParams){
         String value = (String)this.locationHashtable.get(requestParams.getPath());
         return value == null ? "" : LOCATION_KEY + ": " + value;
     }

--- a/src/main/java/com/server/RequestHeaderParser.java
+++ b/src/main/java/com/server/RequestHeaderParser.java
@@ -8,9 +8,11 @@ public class RequestHeaderParser {
 
     private String headerString;
     private RequestParams requestParams;
+    private String directory;
 
-    RequestHeaderParser(String headerString) throws UnsupportedEncodingException {
+    RequestHeaderParser(String headerString, String directory) throws UnsupportedEncodingException {
         this.headerString = headerString;
+        this.directory = directory;
         buildRequestParams();
     }
 
@@ -18,9 +20,14 @@ public class RequestHeaderParser {
         requestParams = new RequestParamsBuilder()
                 .setPath(extractPath())
                 .setMethod(extractMethod())
+                .setDirectory(extractDirectory())
                 .setQueryComponent(extractQueryComponent())
                 .setCookies(extractCookies())
                 .build();
+    }
+
+    private String extractDirectory(){
+        return this.directory.trim();
     }
 
     private String extractMethod() {

--- a/src/main/java/com/server/RequestParams.java
+++ b/src/main/java/com/server/RequestParams.java
@@ -8,8 +8,9 @@ public class RequestParams {
     private String method;
     private Hashtable<String, String> queryComponent;
     private Hashtable<String, String> cookies;
+    private String directory;
 
-    public RequestParams(String path, String method, Hashtable<String, String> queryComponent, Hashtable<String, String> cookies) throws NullPointerException {
+    public RequestParams(String path, String method, Hashtable<String, String> queryComponent, Hashtable<String, String> cookies, String directory) throws NullPointerException {
         if ((path == null) || (method == null)) {
             throw new NullPointerException();
         }
@@ -17,6 +18,7 @@ public class RequestParams {
         this.method = method;
         this.queryComponent = queryComponent;
         this.cookies = cookies;
+        this.directory = directory;
     }
 
     public String getPath() {
@@ -33,5 +35,9 @@ public class RequestParams {
 
     public Hashtable getCookies() {
         return this.cookies;
+    }
+
+    public String getDirectory() {
+        return this.directory;
     }
 }

--- a/src/main/java/com/server/RequestParamsBuilder.java
+++ b/src/main/java/com/server/RequestParamsBuilder.java
@@ -7,6 +7,7 @@ public class RequestParamsBuilder {
     private String method;
     private Hashtable<String, String> queryComponent;
     private Hashtable<String, String> cookies;
+    private String directory;
 
     public RequestParamsBuilder setPath(String path) {
         this.path = path;
@@ -28,7 +29,14 @@ public class RequestParamsBuilder {
         return this;
     }
 
-    public RequestParams build() {
-        return new RequestParams(path, method, queryComponent, cookies);
+    public RequestParamsBuilder setDirectory(String s) {
+        this.directory = s;
+        return this;
     }
+
+    public RequestParams build() {
+        return new RequestParams(path, method, queryComponent, cookies, directory);
+    }
+
+
 }

--- a/src/main/java/com/server/ResponseBodyBuilder.java
+++ b/src/main/java/com/server/ResponseBodyBuilder.java
@@ -6,15 +6,17 @@ public class ResponseBodyBuilder {
     private String body = "";
     private String publicDir = "";
     private RequestRouter requestRouter;
+    public ResponseParams responseParams;
 
-    ResponseBodyBuilder(RequestRouter requestRouter, String directory){
+    ResponseBodyBuilder(RequestRouter requestRouter){
         this.requestRouter = requestRouter;
-        this.publicDir = directory;
     }
 
-    public String getBody(RequestParams requestParams) throws IOException {
+    public String getBody(RequestParams requestParams, ResponseParams responseParams) throws IOException {
+        this.responseParams = responseParams;
+
         if (requestParams.getPath().equals("/file1")) {
-            String filePath = this.publicDir + requestParams.getPath();
+            String filePath = requestParams.getDirectory() + requestParams.getPath();
             File file = new File(filePath);
             this.body = getFileContents(file);
         } else if (requestParams.getPath().equals("/coffee")) {
@@ -54,7 +56,7 @@ public class ResponseBodyBuilder {
     }
 
     private String directoryLinksBody(RequestParams requestParams) throws IOException {
-        String dirPath = this.publicDir + requestParams.getPath();
+        String dirPath = requestParams.getDirectory() + requestParams.getPath();
         String linkedFilesBody = getLinkedFiles(dirPath);
         if(!linkedFilesBody.equals("")) {
             return htmlBuilder().replace("$body", linkedFilesBody);

--- a/src/main/java/com/server/ResponseBuilder.java
+++ b/src/main/java/com/server/ResponseBuilder.java
@@ -8,7 +8,7 @@ public class ResponseBuilder {
     private ResponseParams responseParams;
 
     ResponseBuilder(RequestRouter requestRouter){
-        this.responseParams = new ResponseParams();
+        this.responseParams = new ResponseParamsBuilder().build();
         this.responseBodyBuilder = new ResponseBodyBuilder(requestRouter);
         this.responseHeaderBuilder = new ResponseHeaderBuilder(requestRouter);
     }

--- a/src/main/java/com/server/ResponseBuilder.java
+++ b/src/main/java/com/server/ResponseBuilder.java
@@ -5,15 +5,17 @@ import java.io.IOException;
 public class ResponseBuilder {
     private ResponseHeaderBuilder responseHeaderBuilder;
     private ResponseBodyBuilder responseBodyBuilder;
+    private ResponseParams responseParams;
 
-    ResponseBuilder(ResponseHeaderBuilder responseHeaderBuilder, ResponseBodyBuilder responseBodyBuilder){
-        this.responseHeaderBuilder = responseHeaderBuilder;
-        this.responseBodyBuilder = responseBodyBuilder;
+    ResponseBuilder(RequestRouter requestRouter){
+        this.responseParams = new ResponseParams();
+        this.responseBodyBuilder = new ResponseBodyBuilder(requestRouter);
+        this.responseHeaderBuilder = new ResponseHeaderBuilder(requestRouter);
     }
 
     public String getResponse(RequestParams requestParams) throws IOException {
-        String header = this.responseHeaderBuilder.getHeader(requestParams);
-        String body = this.responseBodyBuilder.getBody(requestParams);
+        String body = this.responseBodyBuilder.getBody(requestParams, responseParams);
+        String header = this.responseHeaderBuilder.getHeader(requestParams, this.responseBodyBuilder.responseParams);
 
         return body == null ? header : header + body;
     }

--- a/src/main/java/com/server/ResponseHeaderBuilder.java
+++ b/src/main/java/com/server/ResponseHeaderBuilder.java
@@ -11,24 +11,24 @@ public class ResponseHeaderBuilder {
 
     public String getHeader(RequestParams requestParams, ResponseParams responseParams) {
         StatusHandler statusHandler = new StatusHandler(requestRouter);
-        String statusLine = statusHandler.createLine(requestParams);
+        String statusLine = statusHandler.createLine(requestParams, responseParams);
         appendLine(statusLine);
 
         if (requestRouter.getResponseCode(requestParams) < 400){
             AllowHandler allowHandler = new AllowHandler();
-            String allowLine = allowHandler.createLine(requestParams);
+            String allowLine = allowHandler.createLine(requestParams, responseParams);
             appendLine(allowLine);
 
             LocationHandler locationHandler = new LocationHandler();
-            String locationLine = locationHandler.createLine(requestParams);
+            String locationLine = locationHandler.createLine(requestParams, responseParams);
             appendLine(locationLine);
 
             ContentTypeHandler contentTypeHandler = new ContentTypeHandler();
-            String contentTypeLine = contentTypeHandler.createLine(requestParams);
+            String contentTypeLine = contentTypeHandler.createLine(requestParams, responseParams);
             appendLine(contentTypeLine);
 
             SetCookieHandler setCookieHandler = new SetCookieHandler();
-            String setCookieHandlerLine = setCookieHandler.createLine(requestParams);
+            String setCookieHandlerLine = setCookieHandler.createLine(requestParams, responseParams);
             appendLine(setCookieHandlerLine);
         }
 

--- a/src/main/java/com/server/ResponseHeaderBuilder.java
+++ b/src/main/java/com/server/ResponseHeaderBuilder.java
@@ -9,7 +9,7 @@ public class ResponseHeaderBuilder {
         this.requestRouter = requestRouter;
     }
 
-    public String getHeader(RequestParams requestParams) {
+    public String getHeader(RequestParams requestParams, ResponseParams responseParams) {
         StatusHandler statusHandler = new StatusHandler(requestRouter);
         String statusLine = statusHandler.createLine(requestParams);
         appendLine(statusLine);

--- a/src/main/java/com/server/ResponseParams.java
+++ b/src/main/java/com/server/ResponseParams.java
@@ -1,4 +1,15 @@
 package com.server;
 
 public class ResponseParams {
+
+    private int responseCode;
+
+    public ResponseParams(int responseCode){
+        this.responseCode = responseCode;
+    }
+
+    public int getResponseCode() {
+        return this.responseCode;
+    }
+
 }

--- a/src/main/java/com/server/ResponseParams.java
+++ b/src/main/java/com/server/ResponseParams.java
@@ -1,0 +1,4 @@
+package com.server;
+
+public class ResponseParams {
+}

--- a/src/main/java/com/server/ResponseParamsBuilder.java
+++ b/src/main/java/com/server/ResponseParamsBuilder.java
@@ -1,4 +1,15 @@
 package com.server;
 
 public class ResponseParamsBuilder {
+
+    private int responseCode;
+
+    public ResponseParamsBuilder setResponseCode(int responseCode) {
+        this.responseCode = responseCode;
+        return this;
+    }
+
+    public ResponseParams build() {
+        return new ResponseParams(responseCode);
+    }
 }

--- a/src/main/java/com/server/ResponseParamsBuilder.java
+++ b/src/main/java/com/server/ResponseParamsBuilder.java
@@ -1,0 +1,4 @@
+package com.server;
+
+public class ResponseParamsBuilder {
+}

--- a/src/main/java/com/server/SetCookieHandler.java
+++ b/src/main/java/com/server/SetCookieHandler.java
@@ -10,7 +10,7 @@ public class SetCookieHandler implements IResponseHeaderHandler {
         this.setCookieHashtable = new Hashtable<>();
     }
 
-    public String createLine(RequestParams requestParams){
+    public String createLine(RequestParams requestParams, ResponseParams responseParams){
         if (requestParams.getPath().equals("/cookie")) {
             setCookieHashtable.put("/cookie", cookiePathValue(requestParams));
         }

--- a/src/main/java/com/server/StatusHandler.java
+++ b/src/main/java/com/server/StatusHandler.java
@@ -18,7 +18,7 @@ public class StatusHandler implements IResponseHeaderHandler {
         statusHashtable.put(418, "418 I'm a teapot");
     }
 
-    public String createLine(RequestParams requestParams){
+    public String createLine(RequestParams requestParams, ResponseParams responseParams){
         int responseCode = this.requestRouter.getResponseCode(requestParams);
 
         StringBuilder stringBuilder = new StringBuilder();

--- a/src/test/java/com/server/AllowHandlerTest.java
+++ b/src/test/java/com/server/AllowHandlerTest.java
@@ -11,7 +11,9 @@ public class AllowHandlerTest {
         String method = "OPTIONS";
         AllowHandler allowHandler = new AllowHandler();
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String result = allowHandler.createLine(requestParams);
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
+
+        String result = allowHandler.createLine(requestParams, responseParams);
 
         assertEquals("Allow: GET, PUT, OPTIONS, POST, HEAD", result);
     }
@@ -22,7 +24,9 @@ public class AllowHandlerTest {
         String method = "GET";
         AllowHandler allowHandler = new AllowHandler();
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String result = allowHandler.createLine(requestParams);
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
+
+        String result = allowHandler.createLine(requestParams, responseParams);
 
         assertEquals("", result);
     }

--- a/src/test/java/com/server/ContentTypeHandlerTest.java
+++ b/src/test/java/com/server/ContentTypeHandlerTest.java
@@ -12,7 +12,9 @@ public class ContentTypeHandlerTest {
         String method = "GET";
         ContentTypeHandler contentTypeHandler = new ContentTypeHandler();
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String result = contentTypeHandler.createLine(requestParams);
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
+
+        String result = contentTypeHandler.createLine(requestParams, responseParams);
 
         assertEquals("Content-Type: image/jpeg", result);
     }
@@ -23,7 +25,9 @@ public class ContentTypeHandlerTest {
         String method = "GET";
         ContentTypeHandler contentTypeHandler = new ContentTypeHandler();
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String result = contentTypeHandler.createLine(requestParams);
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
+
+        String result = contentTypeHandler.createLine(requestParams, responseParams);
 
         assertEquals("", result);
     }

--- a/src/test/java/com/server/LocationHandlerTest.java
+++ b/src/test/java/com/server/LocationHandlerTest.java
@@ -12,7 +12,8 @@ public class LocationHandlerTest {
         String method = "GET";
         LocationHandler locationHandler = new LocationHandler();
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String result = locationHandler.createLine(requestParams);
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
+        String result = locationHandler.createLine(requestParams, responseParams);
 
         assertEquals("Location: /", result);
     }
@@ -23,7 +24,9 @@ public class LocationHandlerTest {
         String method = "GET";
         LocationHandler locationHandler = new LocationHandler();
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String result = locationHandler.createLine(requestParams);
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
+
+        String result = locationHandler.createLine(requestParams, responseParams);
 
         assertEquals("", result);
     }

--- a/src/test/java/com/server/RequestHeaderParserTest.java
+++ b/src/test/java/com/server/RequestHeaderParserTest.java
@@ -13,8 +13,9 @@ public class RequestHeaderParserTest {
     public void getVerbReturnsGetHTTPVerb() throws UnsupportedEncodingException {
 
         String headerString = "GET / HTTP/1.1";
+        String directory = "/foo";
 
-        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
 
         assertEquals("GET", requestHeaderParser.getRequestParams().getMethod());
     }
@@ -23,8 +24,9 @@ public class RequestHeaderParserTest {
     public void getVerbReturnsHTTPPostVerb() throws UnsupportedEncodingException {
 
         String headerString = "POST / HTTP/1.1";
+        String directory = "/foo";
 
-        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
 
         assertEquals("POST", requestHeaderParser.getRequestParams().getMethod());
     }
@@ -33,8 +35,9 @@ public class RequestHeaderParserTest {
     public void getRouteReturnsHTTPRoute() throws UnsupportedEncodingException {
 
         String headerString = "POST / HTTP/1.1";
+        String directory = "/foo";
 
-        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
 
         assertEquals("/", requestHeaderParser.getRequestParams().getPath());
     }
@@ -43,8 +46,9 @@ public class RequestHeaderParserTest {
     public void getRouteReturnsFormHTTPRoute() throws UnsupportedEncodingException {
 
         String headerString = "POST /form HTTP/1.1";
+        String directory = "/foo";
 
-        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
 
         assertEquals("/form", requestHeaderParser.getRequestParams().getPath());
     }
@@ -53,8 +57,9 @@ public class RequestHeaderParserTest {
     public void getRouteReturnsPathWithoutQueryComponent() throws UnsupportedEncodingException {
 
         String headerString = "GET /cookie?type=chocolate HTTP/1.1";
+        String directory = "/foo";
 
-        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
 
         assertEquals("/cookie", requestHeaderParser.getRequestParams().getPath());
     }
@@ -63,8 +68,9 @@ public class RequestHeaderParserTest {
     public void getQueryComponentReturnsAHashTableFromRequestURI() throws UnsupportedEncodingException {
 
         String headerString = "GET /cookie?type=chocolate&foo=bar HTTP/1.1";
+        String directory = "/foo";
 
-        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
 
         Hashtable result = requestHeaderParser.getRequestParams().getQueryComponent();
 
@@ -76,8 +82,9 @@ public class RequestHeaderParserTest {
     public void getQueryComponentReturnsADecodedHashTableFromRequestURI() throws UnsupportedEncodingException {
 
         String headerString = "GET /cookie?foo=%3D%40%23%24%25%5E HTTP/1.1";
+        String directory = "/foo";
 
-        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
 
         Hashtable result = requestHeaderParser.getRequestParams().getQueryComponent();
 
@@ -88,8 +95,9 @@ public class RequestHeaderParserTest {
     public void getQueryComponentReturnsAnEmptyHashTableIfNoQueriesAreInURI() throws UnsupportedEncodingException {
 
         String headerString = "GET / HTTP/1.1";
+        String directory = "/foo";
 
-        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
 
         Hashtable result = requestHeaderParser.getRequestParams().getQueryComponent();
 
@@ -100,8 +108,9 @@ public class RequestHeaderParserTest {
     public void getCookiesReturnsAHashTableFromRequestHeaders() throws UnsupportedEncodingException {
 
         String headerString = "GET /cookie HTTP/1.1\r\nCookie: type=chocolate\r\n\r\n";
+        String directory = "/foo";
 
-        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
 
         Hashtable result = requestHeaderParser.getRequestParams().getCookies();
 
@@ -112,8 +121,9 @@ public class RequestHeaderParserTest {
     public void getCookieReturnsAnEmptyHashTableIfNoCookiesInRequestHeaders() throws UnsupportedEncodingException {
 
         String headerString = "GET /cookie?type=chocolate&foo=bar HTTP/1.1";
+        String directory = "/foo";
 
-        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString);
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
 
         Hashtable result = requestHeaderParser.getRequestParams().getCookies();
 

--- a/src/test/java/com/server/ResponseBodyBuilderTest.java
+++ b/src/test/java/com/server/ResponseBodyBuilderTest.java
@@ -13,12 +13,13 @@ public class ResponseBodyBuilderTest {
     public void getBodyReturnsImATeapotIfPathIsCoffee() throws IOException {
         String path = "/coffee";
         String method = "GET";
-        String publicDir = "/foo";
-        RequestRouter rr = new RequestRouter();
 
-        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr, publicDir);
+        RequestRouter rr = new RequestRouter();
+        ResponseParams responseParams = new ResponseParams();
+
+        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String body = responseBodyBuilder.getBody(requestParams);
+        String body = responseBodyBuilder.getBody(requestParams, responseParams);
 
         String expected = "I'm a teapot";
 
@@ -29,15 +30,17 @@ public class ResponseBodyBuilderTest {
     public void getBodyReturnsMmmmChocolateIfRequestIncludesCookie() throws IOException {
         String path = "/eat_cookie";
         String method = "GET";
-        String publicDir = "/foo";
+
         Hashtable<String, String> cookies = new Hashtable<>();
         cookies.put("type", "chocolate");
 
         RequestRouter rr = new RequestRouter();
-        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr, publicDir);
+        ResponseParams responseParams = new ResponseParams();
+
+        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setCookies(cookies).build();
 
-        String body = responseBodyBuilder.getBody(requestParams);
+        String body = responseBodyBuilder.getBody(requestParams, responseParams);
         String expected = "mmmm chocolate";
 
         assertEquals(expected, body);
@@ -49,10 +52,13 @@ public class ResponseBodyBuilderTest {
         String method = "GET";
         File resourcesDirectory = new File("src/test/resources/test-empty");
         String testDir = resourcesDirectory.getAbsolutePath();
+
         RequestRouter rr = new RequestRouter();
-        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr, testDir);
-        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String body = responseBodyBuilder.getBody(requestParams);
+        ResponseParams responseParams = new ResponseParams();
+
+        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setDirectory(testDir).build();
+        String body = responseBodyBuilder.getBody(requestParams, responseParams);
 
         String expected = "";
 
@@ -67,10 +73,11 @@ public class ResponseBodyBuilderTest {
         Hashtable<String, String> queryComponents = new Hashtable<>();
         queryComponents.put("key", "value");
         RequestRouter rr = new RequestRouter();
+        ResponseParams responseParams = new ResponseParams();
 
-        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr, publicDir);
+        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setQueryComponent(queryComponents).build();
-        String body = responseBodyBuilder.getBody(requestParams);
+        String body = responseBodyBuilder.getBody(requestParams, responseParams);
 
         String expected = "key = value";
 
@@ -84,29 +91,15 @@ public class ResponseBodyBuilderTest {
         File resourcesDirectory = new File("src/test/resources/test-file1-contents");
         String testDir = resourcesDirectory.getAbsolutePath();
         RequestRouter rr = new RequestRouter();
-        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr, testDir);
-        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String body = responseBodyBuilder.getBody(requestParams);
+        ResponseParams responseParams = new ResponseParams();
+
+        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setDirectory(testDir).build();
+        String body = responseBodyBuilder.getBody(requestParams, responseParams);
 
         String expected = "file1 contents";
 
         assertEquals(expected, body);
-    }
-
-
-    @Test
-    public void getBodyReturnsListOfFilesIfDIrectoryHasContents() throws IOException {
-        String path = "/";
-        String method = "GET";
-        File resourcesDirectory = new File("src/test/resources/test-listing");
-        String testDir = resourcesDirectory.getAbsolutePath();
-        RequestRouter rr = new RequestRouter();
-        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr, testDir);
-        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String body = responseBodyBuilder.getBody(requestParams);
-
-        assertTrue(body.contains("foo.txt"));
-        assertTrue(body.contains("bar.txt"));
     }
 
     @Test
@@ -116,9 +109,11 @@ public class ResponseBodyBuilderTest {
         File resourcesDirectory = new File("src/test/resources/test-listing");
         String testDir = resourcesDirectory.getAbsolutePath();
         RequestRouter rr = new RequestRouter();
-        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr, testDir);
-        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String body = responseBodyBuilder.getBody(requestParams);
+        ResponseParams responseParams = new ResponseParams();
+
+        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setDirectory(testDir).build();
+        String body = responseBodyBuilder.getBody(requestParams, responseParams);
 
         assertTrue(body.contains("<a href=\""));
         assertTrue(body.contains("foo.txt"));
@@ -132,9 +127,11 @@ public class ResponseBodyBuilderTest {
         File resourcesDirectory = new File("src/test/resources/test-listing");
         String testDir = resourcesDirectory.getAbsolutePath();
         RequestRouter rr = new RequestRouter();
-        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr, testDir);
-        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String body = responseBodyBuilder.getBody(requestParams);
+        ResponseParams responseParams = new ResponseParams();
+
+        ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setDirectory(testDir).build();
+        String body = responseBodyBuilder.getBody(requestParams, responseParams);
 
         assertTrue(body.contains("<a href=\""));
         assertTrue(body.contains("cat-form"));

--- a/src/test/java/com/server/ResponseBodyBuilderTest.java
+++ b/src/test/java/com/server/ResponseBodyBuilderTest.java
@@ -15,7 +15,7 @@ public class ResponseBodyBuilderTest {
         String method = "GET";
 
         RequestRouter rr = new RequestRouter();
-        ResponseParams responseParams = new ResponseParams();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
         ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
@@ -35,7 +35,7 @@ public class ResponseBodyBuilderTest {
         cookies.put("type", "chocolate");
 
         RequestRouter rr = new RequestRouter();
-        ResponseParams responseParams = new ResponseParams();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
         ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setCookies(cookies).build();
@@ -54,7 +54,7 @@ public class ResponseBodyBuilderTest {
         String testDir = resourcesDirectory.getAbsolutePath();
 
         RequestRouter rr = new RequestRouter();
-        ResponseParams responseParams = new ResponseParams();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
         ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setDirectory(testDir).build();
@@ -73,7 +73,7 @@ public class ResponseBodyBuilderTest {
         Hashtable<String, String> queryComponents = new Hashtable<>();
         queryComponents.put("key", "value");
         RequestRouter rr = new RequestRouter();
-        ResponseParams responseParams = new ResponseParams();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
         ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setQueryComponent(queryComponents).build();
@@ -91,7 +91,7 @@ public class ResponseBodyBuilderTest {
         File resourcesDirectory = new File("src/test/resources/test-file1-contents");
         String testDir = resourcesDirectory.getAbsolutePath();
         RequestRouter rr = new RequestRouter();
-        ResponseParams responseParams = new ResponseParams();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
         ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setDirectory(testDir).build();
@@ -109,7 +109,7 @@ public class ResponseBodyBuilderTest {
         File resourcesDirectory = new File("src/test/resources/test-listing");
         String testDir = resourcesDirectory.getAbsolutePath();
         RequestRouter rr = new RequestRouter();
-        ResponseParams responseParams = new ResponseParams();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
         ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setDirectory(testDir).build();
@@ -127,7 +127,7 @@ public class ResponseBodyBuilderTest {
         File resourcesDirectory = new File("src/test/resources/test-listing");
         String testDir = resourcesDirectory.getAbsolutePath();
         RequestRouter rr = new RequestRouter();
-        ResponseParams responseParams = new ResponseParams();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
         ResponseBodyBuilder responseBodyBuilder = new ResponseBodyBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setDirectory(testDir).build();

--- a/src/test/java/com/server/ResponseBuilderTest.java
+++ b/src/test/java/com/server/ResponseBuilderTest.java
@@ -13,8 +13,8 @@ public class ResponseBuilderTest {
         String publicDir = "/foo";
         RequestRouter rr = new RequestRouter();
         ResponseHeaderBuilder rhb = new ResponseHeaderBuilder(rr);
-        ResponseBodyBuilder rbb = new ResponseBodyBuilder(rr, publicDir);
-        ResponseBuilder responseBuilder = new ResponseBuilder(rhb, rbb);
+        ResponseBodyBuilder rbb = new ResponseBodyBuilder(rr);
+        ResponseBuilder responseBuilder = new ResponseBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String response = responseBuilder.getResponse(requestParams);
 
@@ -30,8 +30,8 @@ public class ResponseBuilderTest {
         String publicDir = "/foo";
         RequestRouter rr = new RequestRouter();
         ResponseHeaderBuilder rhb = new ResponseHeaderBuilder(rr);
-        ResponseBodyBuilder rbb = new ResponseBodyBuilder(rr, publicDir);
-        ResponseBuilder responseBuilder = new ResponseBuilder(rhb, rbb);
+        ResponseBodyBuilder rbb = new ResponseBodyBuilder(rr);
+        ResponseBuilder responseBuilder = new ResponseBuilder(rr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
         String response = responseBuilder.getResponse(requestParams);
 

--- a/src/test/java/com/server/ResponseHeaderBuilderTest.java
+++ b/src/test/java/com/server/ResponseHeaderBuilderTest.java
@@ -2,46 +2,50 @@ package com.server;
 
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.junit.Assert.*;
 
 public class ResponseHeaderBuilderTest {
 
     @Test
-    public void getHeaderReturnsAStatusLineByDefault() {
+    public void getHeaderReturnsAStatusLineByDefault() throws IOException {
         String path = "/foo";
         String method = "GET";
+        String directory = "/bar";
         MockRequestRouter mrr = new MockRequestRouter();
         mrr.setResponseCode(200);
-        ResponseHeaderBuilder responseHeaderBuilder = new ResponseHeaderBuilder(mrr);
-        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
+        ResponseBuilder responseBuilder = new ResponseBuilder(mrr);
+        RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setDirectory(directory).build();
 
-        assertEquals("HTTP/1.1 200 OK\r\n\r\n", responseHeaderBuilder.getHeader(requestParams));
+        assertEquals("HTTP/1.1 200 OK\r\n\r\n", responseBuilder.getResponse(requestParams));
     }
 
     @Test
-    public void getHeaderReturnsAFormattedHeaderBasedonPathAndMethod(){
+    public void getHeaderReturnsAFormattedHeaderBasedonPathAndMethod() throws IOException {
         String path = "/method_options";
         String method = "OPTIONS";
         MockRequestRouter mrr = new MockRequestRouter();
         mrr.setResponseCode(200);
-        ResponseHeaderBuilder responseHeaderBuilder = new ResponseHeaderBuilder(mrr);
+        ResponseBuilder responseBuilder = new ResponseBuilder(mrr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String header = responseHeaderBuilder.getHeader(requestParams);
+
+        String response = responseBuilder.getResponse(requestParams);
 
         String expected = "HTTP/1.1 200 OK\r\nAllow: GET, PUT, OPTIONS, POST, HEAD\r\n\r\n";
 
-        assertEquals(expected, header);
+        assertEquals(expected, response);
     }
 
     @Test
-    public void getHeaderReturnsASingle405StatusLine(){
+    public void getHeaderReturnsASingle405StatusLine() throws IOException {
         String path = "/redirect";
         String method = "DELETE";
         MockRequestRouter mrr = new MockRequestRouter();
         mrr.setResponseCode(405);
-        ResponseHeaderBuilder responseHeaderBuilder = new ResponseHeaderBuilder(mrr);
+        ResponseBuilder responseBuilder = new ResponseBuilder(mrr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String header = responseHeaderBuilder.getHeader(requestParams);
+        String header = responseBuilder.getResponse(requestParams);
 
         String expected = "HTTP/1.1 405 Method Not Allowed\r\n\r\n";
 

--- a/src/test/java/com/server/ResponseParamsTest.java
+++ b/src/test/java/com/server/ResponseParamsTest.java
@@ -1,7 +1,16 @@
 package com.server;
 
+import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 public class ResponseParamsTest {
+
+    @Test
+    public void getResponseCodeReturnsAResponseCode(){
+        ResponseParams responseParams = new ResponseParamsBuilder().setResponseCode(200).build();
+
+        assertEquals(200, responseParams.getResponseCode());
+    }
 
 }

--- a/src/test/java/com/server/ResponseParamsTest.java
+++ b/src/test/java/com/server/ResponseParamsTest.java
@@ -1,0 +1,7 @@
+package com.server;
+
+import static org.junit.Assert.*;
+
+public class ResponseParamsTest {
+
+}

--- a/src/test/java/com/server/SetCookieHandlerTest.java
+++ b/src/test/java/com/server/SetCookieHandlerTest.java
@@ -15,8 +15,10 @@ public class SetCookieHandlerTest {
         queryComponent.put("type", "chocolate");
 
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setQueryComponent(queryComponent).build();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
+
         SetCookieHandler setCookieHandler = new SetCookieHandler();
-        String result = setCookieHandler.createLine(requestParams);
+        String result = setCookieHandler.createLine(requestParams, responseParams);
 
         assertEquals("Set-Cookie: type=chocolate", result);
     }
@@ -26,8 +28,10 @@ public class SetCookieHandlerTest {
         String path = "/foo";
         String method = "GET";
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
+
         SetCookieHandler setCookieHandler = new SetCookieHandler();
-        String result = setCookieHandler.createLine(requestParams);
+        String result = setCookieHandler.createLine(requestParams, responseParams);
 
         assertEquals("", result);
     }

--- a/src/test/java/com/server/StatusHandlerTest.java
+++ b/src/test/java/com/server/StatusHandlerTest.java
@@ -14,8 +14,9 @@ public class StatusHandlerTest {
         String path = "foo";
         String method = "bar";
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
-        assertEquals("HTTP/1.1 200 OK", statusHandler.createLine(requestParams));
+        assertEquals("HTTP/1.1 200 OK", statusHandler.createLine(requestParams, responseParams));
     }
 
     @Test
@@ -26,8 +27,9 @@ public class StatusHandlerTest {
         String path = "foo";
         String method = "bar";
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
-        assertEquals("HTTP/1.1 302 Found", statusHandler.createLine(requestParams));
+        assertEquals("HTTP/1.1 302 Found", statusHandler.createLine(requestParams, responseParams));
     }
 
     @Test
@@ -38,8 +40,9 @@ public class StatusHandlerTest {
         String path = "foo";
         String method = "bar";
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
-        assertEquals("HTTP/1.1 404 Not Found", statusHandler.createLine(requestParams));
+        assertEquals("HTTP/1.1 404 Not Found", statusHandler.createLine(requestParams, responseParams));
     }
 
     @Test
@@ -50,8 +53,9 @@ public class StatusHandlerTest {
         String path = "foo";
         String method = "bar";
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
-        assertEquals("HTTP/1.1 405 Method Not Allowed", statusHandler.createLine(requestParams));
+        assertEquals("HTTP/1.1 405 Method Not Allowed", statusHandler.createLine(requestParams, responseParams));
     }
 
 }


### PR DESCRIPTION
## Pivotal Link
https://www.pivotaltracker.com/story/show/159208119

## Description
- Created a placeholder for a `ResponseParams` object and a placeholder for a `ResponseParamsBuilder` object
- Refactored `HTTPServerManager` to only make a call to `ResponseBuilder` instead of `ResponseHeaderBuilder` and `ResponseBodyBuilder`
- Refactored `ResponseBuilder` to instantiate the as yet empty `ResponseParams` object
- Refactored `ResponseBuilder` to instantiate the `ResponseBodyBuilder` method first, and the `ResponseHeaderBuilder` method next, sending in the `RequestParams` and the `ResponseParams` objects
- `ResponseHeaderBuilder` takes in the `ResponseBodyBuilder's ResponseParams object` AFTER it has been updated.
- Refactored the `ResponseBodyBuilder` class and tests to use the directory path which has now been moved to the `RequestParams` object.
- Refactored to send the `responseParams` object to the `IResponseHeaderHandler` interface and its implementors