### PR TITLE
feature/partial_content

### DIFF
--- a/src/main/java/com/server/PartialContentHandler.java
+++ b/src/main/java/com/server/PartialContentHandler.java
@@ -1,0 +1,22 @@
+package com.server;
+
+public class PartialContentHandler {
+    private static final String PARTIAL_CONTENT_KEY = "Content-Range";
+    private static final String PARTIAL_CONTENT_UNIT = "bytes";
+
+    public String createLine(RequestParams requestParams, ResponseParams responseParams) {
+        if (responseParams.getResponseCode() != 0) {
+            int responseCode = responseParams.getResponseCode();
+            if (responseCode == 206) {
+                int start = responseParams.getContentRange().get("start");
+                int stop = responseParams.getContentRange().get("stop");
+                int contentLength = responseParams.getContentLength();
+                return PARTIAL_CONTENT_KEY + ": " + PARTIAL_CONTENT_UNIT + " " + start + "-" + stop + "/" + contentLength;
+            } else if (responseCode == 416) {
+                int contentLength = responseParams.getContentLength();
+                return PARTIAL_CONTENT_KEY + ": " + PARTIAL_CONTENT_UNIT + " " + "*/" + contentLength;
+            }
+        }
+        return "";
+    }
+}

--- a/src/main/java/com/server/RequestHeaderParser.java
+++ b/src/main/java/com/server/RequestHeaderParser.java
@@ -23,6 +23,7 @@ public class RequestHeaderParser {
                 .setDirectory(extractDirectory())
                 .setQueryComponent(extractQueryComponent())
                 .setCookies(extractCookies())
+                .setRange(extractRange())
                 .build();
     }
 
@@ -82,6 +83,35 @@ public class RequestHeaderParser {
             }
         }
         return cookieTable;
+    }
+
+    private Hashtable<String, Integer> extractRange() {
+        Hashtable<String, Integer> rangeTable = new Hashtable<>();
+        if (headerString.contains("Range")){
+            String rangeLine = "";
+            String[] headerLines = headerString.split("\r\n");
+            for (String headerLine : headerLines){
+                if (headerLine.contains("Range")){
+                    rangeLine = headerLine;
+                    break;
+                }
+            }
+
+            rangeLine = rangeLine.replace("Range: bytes=", "");
+
+            int start = -1;
+            if (!rangeLine.split("[-]")[0].equals("")){
+                start = Integer.parseInt(rangeLine.split("-")[0]);
+            }
+            rangeTable.put("start", start);
+
+            int stop = -1;
+            if (rangeLine.split("[-]").length > 1){
+                stop = Integer.parseInt(rangeLine.split("-")[1]);
+            }
+            rangeTable.put("stop", stop);
+        }
+        return rangeTable;
     }
 
     public RequestParams getRequestParams() {

--- a/src/main/java/com/server/RequestParams.java
+++ b/src/main/java/com/server/RequestParams.java
@@ -9,8 +9,9 @@ public class RequestParams {
     private Hashtable<String, String> queryComponent;
     private Hashtable<String, String> cookies;
     private String directory;
+    private Hashtable<String, Integer> range;
 
-    public RequestParams(String path, String method, Hashtable<String, String> queryComponent, Hashtable<String, String> cookies, String directory) throws NullPointerException {
+    public RequestParams(String path, String method, Hashtable<String, String> queryComponent, Hashtable<String, String> cookies, String directory, Hashtable<String, Integer> range) throws NullPointerException {
         if ((path == null) || (method == null)) {
             throw new NullPointerException();
         }
@@ -19,6 +20,7 @@ public class RequestParams {
         this.queryComponent = queryComponent;
         this.cookies = cookies;
         this.directory = directory;
+        this.range = range;
     }
 
     public String getPath() {
@@ -39,5 +41,9 @@ public class RequestParams {
 
     public String getDirectory() {
         return this.directory;
+    }
+
+    public Hashtable<String, Integer> getRange() {
+        return this.range;
     }
 }

--- a/src/main/java/com/server/RequestParamsBuilder.java
+++ b/src/main/java/com/server/RequestParamsBuilder.java
@@ -8,6 +8,7 @@ public class RequestParamsBuilder {
     private Hashtable<String, String> queryComponent;
     private Hashtable<String, String> cookies;
     private String directory;
+    private Hashtable<String, Integer> range;
 
     public RequestParamsBuilder setPath(String path) {
         this.path = path;
@@ -34,8 +35,13 @@ public class RequestParamsBuilder {
         return this;
     }
 
+    public RequestParamsBuilder setRange(Hashtable<String, Integer> range) {
+        this.range = range;
+        return this;
+    }
+
     public RequestParams build() {
-        return new RequestParams(path, method, queryComponent, cookies, directory);
+        return new RequestParams(path, method, queryComponent, cookies, directory, range);
     }
 
 

--- a/src/main/java/com/server/ResponseHeaderBuilder.java
+++ b/src/main/java/com/server/ResponseHeaderBuilder.java
@@ -14,7 +14,7 @@ public class ResponseHeaderBuilder {
         String statusLine = statusHandler.createLine(requestParams, responseParams);
         appendLine(statusLine);
 
-        if (requestRouter.getResponseCode(requestParams) < 400){
+        if (requestRouter.getResponseCode(requestParams) < 400 || responseParams.getResponseCode() != 0){
             AllowHandler allowHandler = new AllowHandler();
             String allowLine = allowHandler.createLine(requestParams, responseParams);
             appendLine(allowLine);
@@ -28,12 +28,16 @@ public class ResponseHeaderBuilder {
             appendLine(contentTypeLine);
 
             ContentLengthHandler contentLengthHandler = new ContentLengthHandler(requestParams.getDirectory());
-            String contentLengthLine = contentLengthHandler.createLine(requestParams, new ResponseParams(200));
+            String contentLengthLine = contentLengthHandler.createLine(requestParams,responseParams);
             appendLine(contentLengthLine);
 
             SetCookieHandler setCookieHandler = new SetCookieHandler();
             String setCookieHandlerLine = setCookieHandler.createLine(requestParams, responseParams);
             appendLine(setCookieHandlerLine);
+
+            PartialContentHandler partialContentHandler = new PartialContentHandler();
+            String partialContentLine = partialContentHandler.createLine(requestParams, responseParams);
+            appendLine(partialContentLine);
         }
         String endOfHeader = "\r\n";
 

--- a/src/main/java/com/server/ResponseParams.java
+++ b/src/main/java/com/server/ResponseParams.java
@@ -1,15 +1,29 @@
 package com.server;
 
+import java.util.Hashtable;
+
 public class ResponseParams {
 
     private int responseCode;
+    private int contentLength;
+    private Hashtable<String, Integer> contentRange;
 
-    public ResponseParams(int responseCode){
+    public ResponseParams(int responseCode, int contentLength, Hashtable<String, Integer> contentRange){
         this.responseCode = responseCode;
+        this.contentLength = contentLength;
+        this.contentRange = contentRange;
     }
 
     public int getResponseCode() {
         return this.responseCode;
+    }
+
+    public int getContentLength() {
+        return this.contentLength;
+    }
+
+    public Hashtable<String, Integer> getContentRange() {
+        return this.contentRange;
     }
 
 }

--- a/src/main/java/com/server/ResponseParamsBuilder.java
+++ b/src/main/java/com/server/ResponseParamsBuilder.java
@@ -1,15 +1,31 @@
 package com.server;
 
+import java.util.Hashtable;
+
 public class ResponseParamsBuilder {
 
     private int responseCode;
+    private int contentLength;
+    private Hashtable<String, Integer> contentRange;
 
     public ResponseParamsBuilder setResponseCode(int responseCode) {
         this.responseCode = responseCode;
         return this;
     }
 
+    public ResponseParamsBuilder setContentLength(int contentLength) {
+        this.contentLength = contentLength;
+        return this;
+    }
+
+    public ResponseParamsBuilder setContentRange(int start, int stop) {
+        this.contentRange = new Hashtable<>();
+        this.contentRange.put("start", start);
+        this.contentRange.put("stop", stop);
+        return this;
+    }
+
     public ResponseParams build() {
-        return new ResponseParams(responseCode);
+        return new ResponseParams(responseCode, contentLength, contentRange);
     }
 }

--- a/src/main/java/com/server/StatusHandler.java
+++ b/src/main/java/com/server/StatusHandler.java
@@ -12,14 +12,21 @@ public class StatusHandler implements IResponseHeaderHandler {
         this.statusHashtable = new Hashtable();
         this.requestRouter = requestRouter;
         statusHashtable.put(200, "200 OK");
+        statusHashtable.put(206, "206 Partial Content");
         statusHashtable.put(302, "302 Found");
         statusHashtable.put(404, "404 Not Found");
         statusHashtable.put(405, "405 Method Not Allowed");
+        statusHashtable.put(416, "416 Range Not Satisfiable");
         statusHashtable.put(418, "418 I'm a teapot");
     }
 
     public String createLine(RequestParams requestParams, ResponseParams responseParams){
-        int responseCode = this.requestRouter.getResponseCode(requestParams);
+        int responseCode;
+        if(responseParams.getResponseCode() != 0){
+            responseCode = responseParams.getResponseCode();
+        } else {
+            responseCode = this.requestRouter.getResponseCode(requestParams);
+        }
 
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append(HTTP_VERSION);

--- a/src/test/java/com/server/ContentLengthHandlerTest.java
+++ b/src/test/java/com/server/ContentLengthHandlerTest.java
@@ -16,7 +16,8 @@ public class ContentLengthHandlerTest {
         String testDir = resourcesDirectory.getAbsolutePath();
         ContentLengthHandler contentLengthHandler = new ContentLengthHandler(testDir);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String result = contentLengthHandler.createLine(requestParams, new ResponseParams(200));
+        ResponseParams responseParams = new ResponseParamsBuilder().setResponseCode(200).build();
+        String result = contentLengthHandler.createLine(requestParams, responseParams);
 
         assertEquals("Content-Length: 157751", result);
     }
@@ -29,7 +30,8 @@ public class ContentLengthHandlerTest {
         String testDir = resourcesDirectory.getAbsolutePath();
         ContentLengthHandler contentLengthHandler = new ContentLengthHandler(testDir);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String result = contentLengthHandler.createLine(requestParams, new ResponseParams(200));
+        ResponseParams responseParams = new ResponseParamsBuilder().setResponseCode(200).build();
+        String result = contentLengthHandler.createLine(requestParams, responseParams);
 
         assertEquals("Content-Length: 108763", result);
     }
@@ -42,7 +44,8 @@ public class ContentLengthHandlerTest {
         String testDir = resourcesDirectory.getAbsolutePath();
         ContentLengthHandler contentLengthHandler = new ContentLengthHandler(testDir);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String result = contentLengthHandler.createLine(requestParams, new ResponseParams(200));
+        ResponseParams responseParams = new ResponseParamsBuilder().setResponseCode(200).build();
+        String result = contentLengthHandler.createLine(requestParams, responseParams);
 
         assertEquals("Content-Length: 81892", result);
     }
@@ -55,7 +58,8 @@ public class ContentLengthHandlerTest {
         String testDir = resourcesDirectory.getAbsolutePath();
         ContentLengthHandler contentLengthHandler = new ContentLengthHandler(testDir);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
-        String result = contentLengthHandler.createLine(requestParams, new ResponseParams(200));
+        ResponseParams responseParams = new ResponseParamsBuilder().setResponseCode(200).build();
+        String result = contentLengthHandler.createLine(requestParams, responseParams);
 
         assertEquals("", result);
     }

--- a/src/test/java/com/server/PartialContentHandlerTest.java
+++ b/src/test/java/com/server/PartialContentHandlerTest.java
@@ -1,0 +1,66 @@
+package com.server;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PartialContentHandlerTest {
+
+    @Test
+    public void createLineReturnsANewPartialContentLineFor206() {
+        String path = "foo";
+        String method = "BAR";
+        PartialContentHandler partialContentHandler = new PartialContentHandler();
+        RequestParams requestParams = new RequestParamsBuilder()
+                .setPath(path)
+                .setMethod(method)
+                .build();
+        ResponseParams responseParams = new ResponseParamsBuilder()
+                .setResponseCode(206)
+                .setContentLength(500)
+                .setContentRange(100, 200)
+                .build();
+
+        String expected = "Content-Range: bytes 100-200/500";
+        String result = partialContentHandler.createLine(requestParams, responseParams);
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void createLineReturnsANewPartialContentLineFor416() {
+        String path = "foo";
+        String method = "BAR";
+        PartialContentHandler partialContentHandler = new PartialContentHandler();
+        RequestParams requestParams = new RequestParamsBuilder()
+                .setPath(path)
+                .setMethod(method)
+                .build();
+        ResponseParams responseParams = new ResponseParamsBuilder()
+                .setResponseCode(416)
+                .setContentLength(500)
+                .build();
+
+        String expected = "Content-Range: bytes */500";
+        String result = partialContentHandler.createLine(requestParams, responseParams);
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void createLineReturnsAnEmptyString() {
+        String path = "foo";
+        String method = "BAR";
+        PartialContentHandler partialContentHandler = new PartialContentHandler();
+        RequestParams requestParams = new RequestParamsBuilder()
+                .setPath(path)
+                .setMethod(method)
+                .build();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
+
+        String expected = "";
+        String result = partialContentHandler.createLine(requestParams, responseParams);
+
+        assertEquals(expected, result);
+    }
+}

--- a/src/test/java/com/server/RequestHeaderParserTest.java
+++ b/src/test/java/com/server/RequestHeaderParserTest.java
@@ -129,4 +129,57 @@ public class RequestHeaderParserTest {
 
         assertEquals(new Hashtable(), result);
     }
+    @Test
+    public void requestParamsReturnsRequestParamsWithRangeTable() throws UnsupportedEncodingException {
+        String directory = "/public";
+        String headerString = "GET /foo HTTP/1.1\r\nRange: bytes=1-2\r\n";
+
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
+
+        Hashtable result = requestHeaderParser.getRequestParams().getRange();
+
+        assertEquals(1, result.get("start"));
+        assertEquals(2, result.get("stop"));
+
+    }
+
+    @Test
+    public void requestParamsReturnsRequestParamsWithDefaultStartRangeTable() throws UnsupportedEncodingException {
+        String directory = "/public";
+        String headerString = "GET /foo HTTP/1.1\r\nRange: bytes=-2\r\n";
+
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
+
+        Hashtable result = requestHeaderParser.getRequestParams().getRange();
+
+        assertEquals(-1, result.get("start"));
+        assertEquals(2, result.get("stop"));
+
+    }
+
+    @Test
+    public void requestParamsReturnsRequestParamsWithDefaultEndRangeTable() throws UnsupportedEncodingException {
+        String directory = "/public";
+        String headerString = "GET /foo HTTP/1.1\r\nRange: bytes=2-\r\n";
+
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
+
+        Hashtable result = requestHeaderParser.getRequestParams().getRange();
+
+        assertEquals(2, result.get("start"));
+        assertEquals(-1, result.get("stop"));
+
+    }
+
+    @Test
+    public void requestParamsReturnsRequestParamsWithEmptyRangeTable() throws UnsupportedEncodingException {
+        String directory = "/public";
+        String headerString = "GET /foo HTTP/1.1\r\n\r\n";
+
+        RequestHeaderParser requestHeaderParser = new RequestHeaderParser(headerString, directory);
+
+        Hashtable result = requestHeaderParser.getRequestParams().getRange();
+
+        assertEquals(new Hashtable(), result);
+    }
 }

--- a/src/test/java/com/server/ResponseHeaderBuilderTest.java
+++ b/src/test/java/com/server/ResponseHeaderBuilderTest.java
@@ -18,8 +18,9 @@ public class ResponseHeaderBuilderTest {
         mrr.setResponseCode(200);
         ResponseHeaderBuilder responseHeaderBuilder = new ResponseHeaderBuilder(mrr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).setDirectory(directory).build();
+        ResponseParams responseParams = new ResponseParamsBuilder().setResponseCode(200).build();
 
-        assertEquals("HTTP/1.1 200 OK\r\n\r\n", new String(responseHeaderBuilder.getHeader(requestParams, new ResponseParams(200))));
+        assertEquals("HTTP/1.1 200 OK\r\n\r\n", new String(responseHeaderBuilder.getHeader(requestParams,responseParams)));
     }
 
     @Test
@@ -30,8 +31,9 @@ public class ResponseHeaderBuilderTest {
         mrr.setResponseCode(200);
         ResponseHeaderBuilder responseHeaderBuilder = new ResponseHeaderBuilder(mrr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
+        ResponseParams responseParams = new ResponseParamsBuilder().setResponseCode(200).build();
 
-        String header = new String(responseHeaderBuilder.getHeader(requestParams, new ResponseParams(200)));
+        String header = new String(responseHeaderBuilder.getHeader(requestParams, responseParams));
 
         String expected = "HTTP/1.1 200 OK\r\nAllow: GET, PUT, OPTIONS, POST, HEAD\r\n\r\n";
 
@@ -46,8 +48,9 @@ public class ResponseHeaderBuilderTest {
         mrr.setResponseCode(405);
         ResponseHeaderBuilder responseHeaderBuilder = new ResponseHeaderBuilder(mrr);
         RequestParams requestParams = new RequestParamsBuilder().setPath(path).setMethod(method).build();
+        ResponseParams responseParams = new ResponseParamsBuilder().build();
 
-        String header = new String(responseHeaderBuilder.getHeader(requestParams, new ResponseParams(200)));
+        String header = new String(responseHeaderBuilder.getHeader(requestParams, responseParams));
 
         String expected = "HTTP/1.1 405 Method Not Allowed\r\n\r\n";
 

--- a/src/test/resources/test-partial-content/partial_content.txt
+++ b/src/test/resources/test-partial-content/partial_content.txt
@@ -1,0 +1,1 @@
+This is a file that contains text to read part of in order to fulfill a 206.


### PR DESCRIPTION
## Pivotal Link
https://www.pivotaltracker.com/story/show/159011784

## Description 

1. An incoming request's `Range` header is parsed and stored in `Hashtable<String, Integer>` in the `requestParams` object with keys `"start"` and `"stop"`
2. Next, `BodyBuilder.getBody()` sees the request for `/partial_content` and delegates to the `partialContentBody()` method
3. The method uses the `requestParams.getRange()` `HashTable` to get the `"start"` and `"stop"` range of the request
4. Because of cobspec's sensitive personality, weird conditional logic is put in place to determine the _real_ starting and stoping place to do a `substring()`
5. `bodyBuilder.partialContentBody()` also update the `responseParams` object with either a `206` or `416` `responseCode` as well as the `contentLength` and `contentRange`, where applicable.
6. A test fixture at `src/test/resources/test-partial-content/partial_content.txt` was added.
7. (`responseParams.setContentRange(int Start, int Stop` is a helper function to set the `"start"` and `"stop"` key-value pairs on the underlying `ResponseParam` object's `contentRange` attribute)
8. `responseBuilder` passes the updated `bodyBuilder.responseParams` to the `headerBuilder` where it checks for a `responseParams.getResponseCode` and uses that to build the status line, as does the `partialContentHandler`, which uses the properties on `responseParams` to populate the `Partial-Content` response header
9. NOTE: `RequestRouter`'s Hashtable needed to be updated, otherwise `responseHeaderBuilder` would default to a `404 Not Found` status line with no additional headers.

Also in this PR is an updating of all tests to use `ResponseParamsBuilder` to instantiate new `responseParams` objects, rather than the constructor which now accepts a few new parameters.